### PR TITLE
Fix String Error

### DIFF
--- a/main.js
+++ b/main.js
@@ -237,7 +237,7 @@ async function main() {
 		//console.log(req);
 		//console.log(res);
 		console.log("*wildcard* replying to", req.socket.remoteAddress, "asking for", req.url)
-		let html = execSync("./pages/home.php");
+		let html = "" + execSync("./pages/home.php");
 		stringsToRemove.forEach(string => {
 			html = html.replace(string, "");
 		});


### PR DESCRIPTION
Properly set the `html` variable to a string so that the replace function exists.