### PR TITLE
Clean Log Warnings, Enhance Runnability

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 'use strict';
 /*
 	2022-09-14 Hyperling

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "dependencies": {
     "express": ">=4.18.1"
+  },
+  "scripts": {
+    "start": "node ./main.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "express": ">=4.18.1"
   },
   "scripts": {
-    "start": "node ./main.js"
+    "start": "./run.sh"
   }
 }

--- a/pages/helpers/body_open.php
+++ b/pages/helpers/body_open.php
@@ -8,6 +8,6 @@
 <?php
 	include "banner.php";
 	include "menu.php";
-	if ($GLOBALS["ADVISORY"] !== false)
+	if (isset($GLOBALS["ADVISORY"]) && $GLOBALS["ADVISORY"] !== false)
 		include "advisory.php";
 ?>

--- a/pages/helpers/body_open.php
+++ b/pages/helpers/body_open.php
@@ -8,6 +8,6 @@
 <?php
 	include "banner.php";
 	include "menu.php";
-	if (isset($GLOBALS["ADVISORY"]) && $GLOBALS["ADVISORY"] !== false)
+	if (!isset($GLOBALS["ADVISORY"]) || $GLOBALS["ADVISORY"] !== false)
 		include "advisory.php";
 ?>

--- a/run.sh
+++ b/run.sh
@@ -43,6 +43,7 @@ cd $DIR
 
 sudo=""
 if [[ $LOGNAME != "root" ]]; then
+	echo "`date` - Using sudo since user is '$LOGNAME'."
 	sudo="sudo"
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -72,8 +72,8 @@ find ./pages/ | while read file; do
 	chmod -c $mode $file
 done
 
-###echo "`date` - Check if any node modules need updated/installed."
-###npm install
+echo "`date` - Check if any node modules need updated/installed."
+npm install
 
 ## Main ##
 

--- a/run.sh
+++ b/run.sh
@@ -41,7 +41,7 @@ done
 # Ensure we are executing from this file's directory.
 cd $DIR
 
-echo "`date` - Check if any dependencies need installed."
+echo "`date` - Check if any system dependencies need installed."
 if [[ ! `which php` || ! `which node`|| ! `which npm` ]]; then
 	sudo apt install -y php-fpm nodejs npm 2>&1
 fi
@@ -57,7 +57,7 @@ find ./pages/ | while read file; do
 	chmod -c $mode $file 2>&1
 done
 
-echo "`date` - Check if any modules need updated/installed."
+echo "`date` - Check if any node modules need updated/installed."
 npm install 2>&1
 
 ## Main ##

--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,7 @@ done
 cd $DIR
 
 sudo=""
-if [[ $LOGNAME != "root" ]];
+if [[ $LOGNAME != "root" ]]; then
 	sudo="sudo"
 fi
 
@@ -77,7 +77,7 @@ npm install 2>&1
 ## Main ##
 
 echo "`date` - Start website API."
-node ./main.js $ports 2>&1
+npm start -- $ports 2>&1
 status=$?
 
 ## Finish ##

--- a/run.sh
+++ b/run.sh
@@ -42,8 +42,17 @@ done
 cd $DIR
 
 echo "`date` - Check if any system dependencies need installed."
-if [[ ! `which php` || ! `which node`|| ! `which npm` ]]; then
-	sudo apt install -y php-fpm nodejs npm 2>&1
+if [[ ! `which php` ]]; then
+	echo "- Installing PHP"
+	sudo apt install -y php-fpm 2>&1
+fi
+if [[ ! `which node` ]]; then
+	echo "- Installing Node"
+	sudo apt install -y nodejs 2>&1
+fi
+if [[ ! `which npm` ]]; then
+	echo "- Installing NPM"
+	sudo apt install -y npm 2>&1
 fi
 
 # Directories and allowed page types are executable, others are not.

--- a/run.sh
+++ b/run.sh
@@ -50,7 +50,7 @@ fi
 echo "`date` - Check if any system dependencies need installed."
 if [[ ! `which php` ]]; then
 	echo "- Installing PHP"
-	$sudo apt-get install -y php-fpm
+	$sudo apt-get install -y php-cli
 fi
 if [[ ! `which node` ]]; then
 	echo "- Installing Node"

--- a/run.sh
+++ b/run.sh
@@ -49,15 +49,15 @@ fi
 echo "`date` - Check if any system dependencies need installed."
 if [[ ! `which php` ]]; then
 	echo "- Installing PHP"
-	$sudo apt install -y php-fpm 2>&1
+	$sudo apt install -y php-fpm
 fi
 if [[ ! `which node` ]]; then
 	echo "- Installing Node"
-	$sudo apt install -y nodejs 2>&1
+	$sudo apt install -y nodejs
 fi
 if [[ ! `which npm` ]]; then
 	echo "- Installing NPM"
-	$sudo apt install -y npm 2>&1
+	$sudo apt install -y npm
 fi
 
 # Directories and allowed page types are executable, others are not.
@@ -68,16 +68,16 @@ find ./pages/ | while read file; do
 	else
 		mode=644
 	fi
-	chmod -c $mode $file 2>&1
+	chmod -c $mode $file
 done
 
 echo "`date` - Check if any node modules need updated/installed."
-npm install 2>&1
+npm install
 
 ## Main ##
 
 echo "`date` - Start website API."
-npm start -- $ports 2>&1
+npm start -- $ports
 status=$?
 
 ## Finish ##

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ cd $DIR
 
 echo "`date` - Check if any dependencies need installed."
 if [[ ! `which php` || ! `which node`|| ! `which npm` ]]; then
-	sudo apt install -y php-fpm nodejs npm
+	sudo apt install -y php-fpm nodejs npm 2>&1
 fi
 
 # Directories and allowed page types are executable, others are not.
@@ -54,16 +54,16 @@ find ./pages/ | while read file; do
 	else
 		mode=644
 	fi
-	chmod -c $mode $file
+	chmod -c $mode $file 2>&1
 done
 
 echo "`date` - Check if any modules need updated/installed."
-npm install
+npm install 2>&1
 
 ## Main ##
 
 echo "`date` - Start website API."
-./main.js $ports
+./main.js $ports 2>&1
 status=$?
 
 ## Finish ##

--- a/run.sh
+++ b/run.sh
@@ -77,7 +77,7 @@ npm install 2>&1
 ## Main ##
 
 echo "`date` - Start website API."
-./main.js $ports 2>&1
+node ./main.js $ports 2>&1
 status=$?
 
 ## Finish ##

--- a/run.sh
+++ b/run.sh
@@ -78,7 +78,7 @@ npm install
 ## Main ##
 
 echo "`date` - Start website API."
-npm start -- $ports
+node ./main.js $ports
 status=$?
 
 ## Finish ##

--- a/run.sh
+++ b/run.sh
@@ -41,18 +41,23 @@ done
 # Ensure we are executing from this file's directory.
 cd $DIR
 
+sudo=""
+if [[ $LOGNAME != "root" ]];
+	sudo="sudo"
+fi
+
 echo "`date` - Check if any system dependencies need installed."
 if [[ ! `which php` ]]; then
 	echo "- Installing PHP"
-	sudo apt install -y php-fpm 2>&1
+	$sudo apt install -y php-fpm 2>&1
 fi
 if [[ ! `which node` ]]; then
 	echo "- Installing Node"
-	sudo apt install -y nodejs 2>&1
+	$sudo apt install -y nodejs 2>&1
 fi
 if [[ ! `which npm` ]]; then
 	echo "- Installing NPM"
-	sudo apt install -y npm 2>&1
+	$sudo apt install -y npm 2>&1
 fi
 
 # Directories and allowed page types are executable, others are not.

--- a/run.sh
+++ b/run.sh
@@ -50,15 +50,15 @@ fi
 echo "`date` - Check if any system dependencies need installed."
 if [[ ! `which php` ]]; then
 	echo "- Installing PHP"
-	$sudo apt install -y php-fpm
+	$sudo apt-get install -y php-fpm
 fi
 if [[ ! `which node` ]]; then
 	echo "- Installing Node"
-	$sudo apt install -y nodejs
+	$sudo apt-get install -y nodejs
 fi
 if [[ ! `which npm` ]]; then
 	echo "- Installing NPM"
-	$sudo apt install -y npm
+	$sudo apt-get install -y npm
 fi
 
 # Directories and allowed page types are executable, others are not.
@@ -72,8 +72,8 @@ find ./pages/ | while read file; do
 	chmod -c $mode $file
 done
 
-echo "`date` - Check if any node modules need updated/installed."
-npm install
+###echo "`date` - Check if any node modules need updated/installed."
+###npm install
 
 ## Main ##
 


### PR DESCRIPTION
Remove warnings about an unset variable and apt not having a stable CLI.

Fix node's shebang, only install each system dependency one at a time so that newer versions don't get added if, say, php-8.1 is installed and php-8.2 would get installed via php-cli.

Add ability to run project using shortcut `npm start`.